### PR TITLE
Add rescue clause on json parse

### DIFF
--- a/lib/databasedotcom.rb
+++ b/lib/databasedotcom.rb
@@ -1,5 +1,6 @@
 require 'active_support/core_ext'
 
+require 'databasedotcom/utils'
 require 'databasedotcom/version'
 require 'databasedotcom/core_extensions'
 require 'databasedotcom/client'

--- a/lib/databasedotcom/chatter/feed.rb
+++ b/lib/databasedotcom/chatter/feed.rb
@@ -22,7 +22,7 @@ module Databasedotcom
         path_components << "feed-items"
         path = "/" + path_components.compact.join('/')
         result = client.http_get(path)
-        response = JSON.parse(result.body)
+        response = Databasedotcom::Utils.emoji_safe_json_parse(result.body)
         collection = self.new(client, nil, response["nextPageUrl"], response["previousPageUrl"], response["currentPageUrl"])
         response["items"].each do |item|
           collection << FeedItem.new(client, item)

--- a/lib/databasedotcom/chatter/filter_feed.rb
+++ b/lib/databasedotcom/chatter/filter_feed.rb
@@ -7,7 +7,7 @@ module Databasedotcom
       def self.feeds(client, user_id="me")
         url = "/services/data/v#{client.version}/chatter/feeds/filter/#{user_id}"
         result = client.http_get(url)
-        JSON.parse(result.body)
+        Databasedotcom::Utils.emoji_safe_json_parse(result.body)
       end
     end
   end

--- a/lib/databasedotcom/chatter/group.rb
+++ b/lib/databasedotcom/chatter/group.rb
@@ -11,7 +11,7 @@ module Databasedotcom
       def self.members(client, group_id)
         url = "/services/data/v#{client.version}/chatter/groups/#{group_id}/members"
         result = client.http_get(url)
-        response = JSON.parse(result.body)
+        response = Databasedotcom::Utils.emoji_safe_json_parse(result.body)
         collection = Databasedotcom::Collection.new(client, response["totalMemberCount"], response["nextPageUrl"], response["previousPageUrl"], response["currentPageUrl"])
         response["members"].each do |member|
           collection << GroupMembership.new(client, member)

--- a/lib/databasedotcom/chatter/photo_methods.rb
+++ b/lib/databasedotcom/chatter/photo_methods.rb
@@ -12,7 +12,7 @@ module Databasedotcom
         def photo(client, resource_id)
           url = "/services/data/v#{client.version}/chatter/#{self.resource_name}/#{resource_id}/photo"
           result = client.http_get(url)
-          JSON.parse(result.body)
+          Databasedotcom::Utils.emoji_safe_json_parse(result.body)
         end
 
         # Uploads a photo for a resource with id _resource_id_.
@@ -21,7 +21,7 @@ module Databasedotcom
         def upload_photo(client, resource_id, io, file_type)
           url = "/services/data/v#{client.version}/chatter/#{self.resource_name}/#{resource_id}/photo"
           result = client.http_multipart_post(url, {"fileUpload" => UploadIO.new(io, file_type)})
-          JSON.parse(result.body)
+          Databasedotcom::Utils.emoji_safe_json_parse(result.body)
         end
 
         # Deletes the photo for the resource with id _resource_id_.

--- a/lib/databasedotcom/chatter/record.rb
+++ b/lib/databasedotcom/chatter/record.rb
@@ -9,7 +9,7 @@ module Databasedotcom
       # Create a new record from the returned JSON response of an API request. Sets the client, name, id, url, and type attributes. Saves the raw response as +raw_hash+.
       def initialize(client, response)
         @client = client
-        @raw_hash = response.is_a?(Hash) ? response : JSON.parse(response)
+        @raw_hash = response.is_a?(Hash) ? response : Databasedotcom::Utils.emoji_safe_json_parse(response)
         @name = @raw_hash["name"]
         @id = @raw_hash["id"]
         @url = @raw_hash["url"]
@@ -21,7 +21,7 @@ module Databasedotcom
         if resource_id.is_a?(Array)
           resource_ids = resource_id.join(',')
           url = "/services/data/v#{client.version}/chatter/#{self.resource_name}/batch/#{resource_ids}"
-          response = JSON.parse(client.http_get(url, parameters).body)
+          response = Databasedotcom::Utils.emoji_safe_json_parse(client.http_get(url, parameters).body)
           good_results = response["results"].select { |r| r["statusCode"] == 200 }
           collection = Databasedotcom::Collection.new(client, good_results.length)
           good_results.each do |result|
@@ -36,7 +36,7 @@ module Databasedotcom
           end
           path_components << "#{self.resource_name}/#{resource_id}"
           url = path_components.join('/')
-          response = JSON.parse(client.http_get(url, parameters).body)
+          response = Databasedotcom::Utils.emoji_safe_json_parse(client.http_get(url, parameters).body)
           self.new(client, response)
         end
       end
@@ -56,7 +56,7 @@ module Databasedotcom
         path_components << self.resource_name
         url = path_components.join('/')
         result = client.http_get(url, parameters)
-        response = JSON.parse(result.body)
+        response = Databasedotcom::Utils.emoji_safe_json_parse(result.body)
         collection = Databasedotcom::Collection.new(client, self.total_size_of_collection(response), response["nextPageUrl"], response["previousPageUrl"], response["currentPageUrl"])
         self.collection_from_response(response).each do |resource|
           collection << self.new(client, resource)

--- a/lib/databasedotcom/chatter/user.rb
+++ b/lib/databasedotcom/chatter/user.rb
@@ -11,7 +11,7 @@ module Databasedotcom
       def self.followers(client, subject_id="me")
         url = "/services/data/v#{client.version}/chatter/users/#{subject_id}/followers"
         result = client.http_get(url)
-        response = JSON.parse(result.body)
+        response = Databasedotcom::Utils.emoji_safe_json_parse(result.body)
         collection = Databasedotcom::Collection.new(client, response["total"], response["nextPageUrl"], response["previousPageUrl"], response["currentPageUrl"])
         response["followers"].each do |subscription|
           collection << Subscription.new(client, subscription)
@@ -23,7 +23,7 @@ module Databasedotcom
       def self.following(client, subject_id="me")
         url = "/services/data/v#{client.version}/chatter/users/#{subject_id}/following"
         result = client.http_get(url)
-        response = JSON.parse(result.body)
+        response = Databasedotcom::Utils.emoji_safe_json_parse(result.body)
         collection = Databasedotcom::Collection.new(client, response["total"], response["nextPageUrl"], response["previousPageUrl"], response["currentPageUrl"])
         response["following"].each do |subscription|
           collection << Subscription.new(client, subscription)
@@ -35,7 +35,7 @@ module Databasedotcom
       def self.groups(client, subject_id="me")
         url = "/services/data/v#{client.version}/chatter/users/#{subject_id}/groups"
         result = client.http_get(url)
-        response = JSON.parse(result.body)
+        response = Databasedotcom::Utils.emoji_safe_json_parse(result.body)
         collection = Databasedotcom::Collection.new(client, response["total"], response["nextPageUrl"], response["previousPageUrl"], response["currentPageUrl"])
         response["groups"].each do |group|
           collection << Group.new(client, group)
@@ -47,14 +47,14 @@ module Databasedotcom
       def self.status(client, subject_id="me")
         url = "/services/data/v#{client.version}/chatter/users/#{subject_id}/status"
         result = client.http_get(url)
-        JSON.parse(result.body)
+        Databasedotcom::Utils.emoji_safe_json_parse(result.body)
       end
 
       # Posts a status update as the User identified by _subject_id_ with content _text_.
       def self.post_status(client, subject_id, text)
         url = "/services/data/v#{client.version}/chatter/users/#{subject_id}/status"
         result = client.http_post(url, nil, :text => text)
-        JSON.parse(result.body)
+        Databasedotcom::Utils.emoji_safe_json_parse(result.body)
       end
 
       # Deletes the status of User identified by _subject_id_.

--- a/lib/databasedotcom/client.rb
+++ b/lib/databasedotcom/client.rb
@@ -150,7 +150,7 @@ module Databasedotcom
     def list_sobjects
       result = http_get("/services/data/v#{self.version}/sobjects")
       if result.is_a?(Net::HTTPOK)
-        JSON.parse(result.body)["sobjects"].collect { |sobject| sobject["name"] }
+        Databasedotcom::Utils.emoji_safe_json_parse(result.body)["sobjects"].collect { |sobject| sobject["name"] }
       elsif result.is_a?(Net::HTTPBadRequest)
         raise SalesForceError.new(result)
       end
@@ -182,13 +182,13 @@ module Databasedotcom
     # Returns an Array of Hashes listing the properties for every type of _Sobject_ in the database. Raises SalesForceError if an error occurs.
     def describe_sobjects
       result = http_get("/services/data/v#{self.version}/sobjects")
-      JSON.parse(result.body)["sobjects"]
+      Databasedotcom::Utils.emoji_safe_json_parse(result.body)["sobjects"]
     end
 
     # Returns a description of the Sobject specified by _class_name_. The description includes all fields and their properties for the Sobject.
     def describe_sobject(class_name)
       result = http_get("/services/data/v#{self.version}/sobjects/#{class_name}/describe")
-      JSON.parse(result.body)
+      Databasedotcom::Utils.emoji_safe_json_parse(result.body)
     end
 
     # Returns an instance of the Sobject specified by _class_or_classname_ (which can be either a String or a Class) populated with the values of the Force.com record specified by _record_id_.
@@ -198,7 +198,7 @@ module Databasedotcom
     def find(class_or_classname, record_id)
       class_or_classname = find_or_materialize(class_or_classname)
       result = http_get("/services/data/v#{self.version}/sobjects/#{class_or_classname.sobject_name}/#{record_id}")
-      response = JSON.parse(result.body)
+      response = Databasedotcom::Utils.emoji_safe_json_parse(result.body)
       new_record = class_or_classname.new
       class_or_classname.description["fields"].each do |field|
         set_value(new_record, field["name"], response[key_from_label(field["label"])] || response[field["name"]], field["type"])
@@ -247,10 +247,10 @@ module Databasedotcom
       json_for_assignment = coerced_json(object_attrs, class_or_classname)
       result = http_post("/services/data/v#{self.version}/sobjects/#{class_or_classname.sobject_name}", json_for_assignment)
       new_object = class_or_classname.new
-      JSON.parse(json_for_assignment).each do |property, value|
+      Databasedotcom::Utils.emoji_safe_json_parse(json_for_assignment).each do |property, value|
         set_value(new_object, property, value, class_or_classname.type_map[property][:type])
       end
-      id = JSON.parse(result.body)["id"]
+      id = Databasedotcom::Utils.emoji_safe_json_parse(result.body)["id"]
       set_value(new_object, "Id", id, "id")
       new_object
     end
@@ -291,7 +291,7 @@ module Databasedotcom
     # Returns an array of trending topic names.
     def trending_topics
       result = http_get("/services/data/v#{self.version}/chatter/topics/trending")
-      result = JSON.parse(result.body)
+      result = Databasedotcom::Utils.emoji_safe_json_parse(result.body)
       result["topics"].collect { |topic| topic["name"] }
     end
 
@@ -446,7 +446,7 @@ module Databasedotcom
     end
 
     def collection_from(response)
-      response = JSON.parse(response)
+      response = Databasedotcom::Utils.emoji_safe_json_parse(response)
       collection_from_hash( response )
     end
 
@@ -557,7 +557,7 @@ module Databasedotcom
     end
 
     def parse_auth_response(body)
-      json = JSON.parse(body)
+      json = Databasedotcom::Utils.emoji_safe_json_parse(body)
       parse_user_id_and_org_id_from_identity_url(json["id"])
       self.instance_url = json["instance_url"]
       self.oauth_token = json["access_token"]

--- a/lib/databasedotcom/sales_force_error.rb
+++ b/lib/databasedotcom/sales_force_error.rb
@@ -8,7 +8,7 @@ module Databasedotcom
 
     def initialize(response)
       self.response = response
-      parsed_body = JSON.parse(response.body) rescue nil
+      parsed_body = Databasedotcom::Utils.emoji_safe_json_parse(response.body) rescue nil
       if parsed_body
         if parsed_body.is_a?(Array)
           message = parsed_body[0]["message"]

--- a/lib/databasedotcom/sobject/sobject.rb
+++ b/lib/databasedotcom/sobject/sobject.rb
@@ -81,7 +81,7 @@ module Databasedotcom
       #    c.update_attributes {"Color" => "Blue", "Year" => "2012"}
       def update_attributes(new_attrs)
         if self.client.update(self.class, self.Id, new_attrs)
-          new_attrs = new_attrs.is_a?(Hash) ? new_attrs : JSON.parse(new_attrs)
+          new_attrs = new_attrs.is_a?(Hash) ? new_attrs : Databasedotcom::Utils.emoji_safe_json_parse(new_attrs)
           new_attrs.each do |attr, value|
             self.send("#{attr}=", value)
           end

--- a/lib/databasedotcom/utils.rb
+++ b/lib/databasedotcom/utils.rb
@@ -5,16 +5,28 @@ module Databasedotcom
     rescue JSON::ParserError => e
       raise e unless e.message.include? 'incomplete surrogate pair'
 
-      matches = data.scan(/(?:\\u[0-9|a-f|A-F]{4})+"/)
+      matches = find_unicode_sequences(data)
 
       matches.each do |match|
-        next if ((match.length - 1) % 12).zero?
+        next if valid_unicode_sequence?(match)
 
-        fixed_match = match[0...-7]
+        fixed_match = remove_incomplete_surrogate_pair(match)
         data.sub!(match, fixed_match + '"')
       end
 
       JSON.parse(data)
+    end
+
+    def find_unicode_sequences(data)
+      data.scan(/(?:\\u[0-9|a-f|A-F]{4})+"/)
+    end
+
+    def valid_unicode_sequence?(match)
+      ((match.length - 1) % 12).zero?
+    end
+
+    def remove_incomplete_surrogate_pair(match)
+      match[0...-7]
     end
   end
 end

--- a/lib/databasedotcom/utils.rb
+++ b/lib/databasedotcom/utils.rb
@@ -8,11 +8,12 @@ module Databasedotcom
       matches = data.scan(/(\\u[0-9|a-f|A-F]{4})+/)
 
       matches.each do |match|
-        next unless match.length % 12 != 0
+        next if (match.length % 12).zero?
 
         fixed_match = match[0...-6]
-        data.gsub!(match, fixed_match)
+        data.gsub!(match + '"', fixed_match + '"')
       end
+
       JSON.parse(data)
     end
   end

--- a/lib/databasedotcom/utils.rb
+++ b/lib/databasedotcom/utils.rb
@@ -7,15 +7,10 @@ module Databasedotcom
 
       matches = data.scan(/(?:\\u[0-9|a-f|A-F]{4})+"/)
 
-      puts matches
-
       matches.each do |match|
-        puts match
         next if ((match.length - 1) % 12).zero?
 
-        puts "Will remove invalid unicode"
         fixed_match = match[0...-7]
-        puts fixed_match
         data.sub!(match, fixed_match + '"')
       end
 

--- a/lib/databasedotcom/utils.rb
+++ b/lib/databasedotcom/utils.rb
@@ -1,0 +1,19 @@
+module Databasedotcom
+  module Utils
+    def self.emoji_safe_json_parse(data)
+      JSON.parse(data)
+    rescue JSON::ParserError => e
+      raise e unless e.message.include? 'incomplete surrogate pair'
+
+      matches = data.scan(/(\\u[0-9|a-f|A-F]{4})+/)
+
+      matches.each do |match|
+        next unless match.length % 12 != 0
+
+        fixed_match = match[0...-6]
+        data.gsub!(match, fixed_match)
+      end
+      JSON.parse(data)
+    end
+  end
+end

--- a/lib/databasedotcom/utils.rb
+++ b/lib/databasedotcom/utils.rb
@@ -5,7 +5,7 @@ module Databasedotcom
     rescue JSON::ParserError => e
       raise e unless e.message.include? 'incomplete surrogate pair'
 
-      matches = data.scan(/(\\u[0-9|a-f|A-F]{4})+/)
+      matches = data.scan(/(\\u[0-9|a-f|A-F]{4})+/).flatten
 
       matches.each do |match|
         next if (match.length % 12).zero?

--- a/lib/databasedotcom/utils.rb
+++ b/lib/databasedotcom/utils.rb
@@ -5,27 +5,27 @@ module Databasedotcom
     rescue JSON::ParserError => e
       raise e unless e.message.include? 'incomplete surrogate pair'
 
-      matches = find_unicode_sequences(data)
+      matches = Utils.find_unicode_sequences(data)
 
       matches.each do |match|
-        next if valid_unicode_sequence?(match)
+        next if Utils.valid_unicode_sequence?(match)
 
-        fixed_match = remove_incomplete_surrogate_pair(match)
+        fixed_match = Utils.remove_incomplete_surrogate_pair(match)
         data.sub!(match, fixed_match + '"')
       end
 
       JSON.parse(data)
     end
 
-    def find_unicode_sequences(data)
+    def self.find_unicode_sequences(data)
       data.scan(/(?:\\u[0-9|a-f|A-F]{4})+"/)
     end
 
-    def valid_unicode_sequence?(match)
+    def self.valid_unicode_sequence?(match)
       ((match.length - 1) % 12).zero?
     end
 
-    def remove_incomplete_surrogate_pair(match)
+    def self.remove_incomplete_surrogate_pair(match)
       match[0...-7]
     end
   end

--- a/lib/databasedotcom/utils.rb
+++ b/lib/databasedotcom/utils.rb
@@ -5,7 +5,7 @@ module Databasedotcom
     rescue JSON::ParserError => e
       raise e unless e.message.include? 'incomplete surrogate pair'
 
-      matches = data.scan(/(\\u[0-9|a-f|A-F]{4})+"/).flatten
+      matches = data.scan(/(?:\\u[0-9|a-f|A-F]{4})+"/)
 
       puts matches
 

--- a/lib/databasedotcom/utils.rb
+++ b/lib/databasedotcom/utils.rb
@@ -5,13 +5,18 @@ module Databasedotcom
     rescue JSON::ParserError => e
       raise e unless e.message.include? 'incomplete surrogate pair'
 
-      matches = data.scan(/(\\u[0-9|a-f|A-F]{4})+/).flatten
+      matches = data.scan(/(\\u[0-9|a-f|A-F]{4})+"/).flatten
+
+      puts matches
 
       matches.each do |match|
-        next if (match.length % 12).zero?
+        puts match
+        next if (match.length - 1 % 12).zero?
 
-        fixed_match = match[0...-6]
-        data.gsub!(match + '"', fixed_match + '"')
+        puts "Will remove invalid unicode"
+        fixed_match = match[0...-7]
+        puts fixed_match
+        data.sub!(match, fixed_match + '"')
       end
 
       JSON.parse(data)

--- a/lib/databasedotcom/utils.rb
+++ b/lib/databasedotcom/utils.rb
@@ -11,7 +11,7 @@ module Databasedotcom
 
       matches.each do |match|
         puts match
-        next if (match.length - 1 % 12).zero?
+        next if ((match.length - 1) % 12).zero?
 
         puts "Will remove invalid unicode"
         fixed_match = match[0...-7]

--- a/spec/lib/chatter/feed_item_spec.rb
+++ b/spec/lib/chatter/feed_item_spec.rb
@@ -7,7 +7,7 @@ describe Databasedotcom::Chatter::FeedItem do
 
   context "with a FeedItem object" do
     before do
-      @response = JSON.parse(File.read(File.join(File.dirname(__FILE__), "../../fixtures/chatter/feed-items_get_id_success_response.json")))
+      @response = Databasedotcom::Utils.emoji_safe_json_parse(File.read(File.join(File.dirname(__FILE__), "../../fixtures/chatter/feed-items_get_id_success_response.json")))
       @client_mock = double("client", :version => "23")
       @record = Databasedotcom::Chatter::FeedItem.new(@client_mock, @response)
     end
@@ -26,7 +26,7 @@ describe Databasedotcom::Chatter::FeedItem do
 
     describe "#like" do
       it "likes the feed item" do
-        body = JSON.parse(File.read(File.join(File.dirname(__FILE__), "../../fixtures/chatter/likes_get_id_success_response.json")))
+        body = Databasedotcom::Utils.emoji_safe_json_parse(File.read(File.join(File.dirname(__FILE__), "../../fixtures/chatter/likes_get_id_success_response.json")))
         @response = double("response")
         @response.should_receive(:body).any_number_of_times.and_return(body)
         @client_mock.should_receive(:http_post).with("/services/data/v23/chatter/feed-items/#{@record.id}/likes").and_return(@response)
@@ -37,7 +37,7 @@ describe Databasedotcom::Chatter::FeedItem do
 
     describe "#comment" do
       it "comments on the feed item" do
-        body = JSON.parse(File.read(File.join(File.dirname(__FILE__), "../../fixtures/chatter/comments_get_id_success_response.json")))
+        body = Databasedotcom::Utils.emoji_safe_json_parse(File.read(File.join(File.dirname(__FILE__), "../../fixtures/chatter/comments_get_id_success_response.json")))
         @response = double("response")
         @response.should_receive(:body).any_number_of_times.and_return(body)
         @client_mock.should_receive(:http_post).with("/services/data/v23/chatter/feed-items/#{@record.id}/comments", nil, :text => "whatever").and_return(@response)

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -259,7 +259,7 @@ describe Databasedotcom::Client do
 
     context "with an omniauth response" do
       before do
-        @response = JSON.parse(File.read(File.join(File.dirname(__FILE__), '..', "fixtures/omniauth_response.json")))
+        @response = Databasedotcom::Utils.emoji_safe_json_parse(File.read(File.join(File.dirname(__FILE__), '..', "fixtures/omniauth_response.json")))
       end
 
       it "parses the response token from the ominauth hash" do
@@ -640,7 +640,7 @@ describe Databasedotcom::Client do
 
           it "initializes attribute values on the returned instance" do
             whizbang = @client.find(MySobjects::Whizbang, "23foo")
-            response = JSON.parse(@response_body)
+            response = Databasedotcom::Utils.emoji_safe_json_parse(@response_body)
             MySobjects::Whizbang.description["fields"].collect { |f| [f["name"], f["label"]] }.each do |name, label|
               unless %w(Date_Field DateTime_Field Picklist_Multiselect_Field OtherDateTime_Field).include?(name)
                 whizbang.send(name.to_sym).should == (response[label.gsub(' ', '_')] || response[name])

--- a/spec/lib/sales_force_error_spec.rb
+++ b/spec/lib/sales_force_error_spec.rb
@@ -6,7 +6,7 @@ describe Databasedotcom::SalesForceError do
   context "with a non-array body" do
     before do
       @response_body = File.read(File.join(File.dirname(__FILE__), "../fixtures/auth_error_response.json"))
-      @response_json = JSON.parse(@response_body)
+      @response_json = Databasedotcom::Utils.emoji_safe_json_parse(@response_body)
       @response = double("result", :body => @response_body)
       @exception = Databasedotcom::SalesForceError.new(@response)
     end
@@ -33,7 +33,7 @@ describe Databasedotcom::SalesForceError do
   context "with a array body" do
     before do
       @response_body = File.read(File.join(File.dirname(__FILE__), "../fixtures/sobject/search_error_response.json"))
-      @response_json = JSON.parse(@response_body)
+      @response_json = Databasedotcom::Utils.emoji_safe_json_parse(@response_body)
       @response = double("result", :body => @response_body)
       @exception = Databasedotcom::SalesForceError.new(@response)
     end

--- a/spec/lib/sobject/sobject_spec.rb
+++ b/spec/lib/sobject/sobject_spec.rb
@@ -14,7 +14,7 @@ describe Databasedotcom::Sobject::Sobject do
 
   describe "materialization" do
     context "with a valid Sobject name" do
-      response = JSON.parse(File.read(File.join(File.dirname(__FILE__), "../../fixtures/sobject/sobject_describe_success_response.json")))
+      response = Databasedotcom::Utils.emoji_safe_json_parse(File.read(File.join(File.dirname(__FILE__), "../../fixtures/sobject/sobject_describe_success_response.json")))
 
       it "requests a description of the class" do
         @client.should_receive(:describe_sobject).with("TestClass").and_return(response)
@@ -76,7 +76,7 @@ describe Databasedotcom::Sobject::Sobject do
 
   context "with a materialized class" do
     before do
-      response = JSON.parse(File.read(File.join(File.dirname(__FILE__), "../../fixtures/sobject/sobject_describe_success_response.json")))
+      response = Databasedotcom::Utils.emoji_safe_json_parse(File.read(File.join(File.dirname(__FILE__), "../../fixtures/sobject/sobject_describe_success_response.json")))
       @client.should_receive(:describe_sobject).with("TestClass").and_return(response)
       TestClass.materialize("TestClass")
       @field_names = TestClass.description["fields"].collect { |f| f["name"] }


### PR DESCRIPTION
This PR will add a safety measure to databasedotcom JSON.parse calls. This measure will ensure that incorrect half broken unicodes are removed from the body of the request.

After the spike conducted, this was the chosen solution.

## Technical Info

The error always occurs when a third party software truncates a string and results in an invalid unicode character with half information. The algorithm implemented will remove the last unicode on an odd sequence of unicodes.

### Implementation Details

The algorithm implemented is as follows:
- Get all sequences of unicodes present at the end of a string ( this is because the error occurs when a third party software truncates the string resulting in an invalid surrogate unicode pair)
- For each match, if the number of unicodes is odd ( meaning there is a dangling pair ), remove the last element.
- For each match upsert, replace the original data when the corrected matches.